### PR TITLE
use actual legacy link

### DIFF
--- a/usage/jailbreak.md
+++ b/usage/jailbreak.md
@@ -14,7 +14,7 @@ description: Learn how to jailbreak your device with palera1n
 * #### First jailbreak
   * Run `./palera1n -f -B`<details><summary>What does this do?</summary>This creates the fakefs but with bind mounts, so it uses a smaller size at the expense of having unwritable parts in rarely-written paths. </details>
 
-* #### If there still isn't enough space, you will have to use palera1n tethered using the [original Shell script](https://github.com/palera1n/palera1n). The C rewrite does not support tethered use at this time.
+* #### If there still isn't enough space, you will have to use palera1n tethered using the [original Shell script](https://github.com/palera1n/palera1n/tree/legacy). The C rewrite does not support tethered use at this time.
 
 
 ## Rootless


### PR DESCRIPTION
make the legacy branch actually link to legacy... (or remove the link, could be done)
pretty useless but can stop people from complaining if they happen to come across it and be unable to find .sh